### PR TITLE
Allow package to be installed from PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, Command
-from vi3o import __version__
 import sys
+
+__version_info__ = (0, 6, 0)
+__version__ = '.'.join(str(i) for i in __version_info__)
 
 class PyTestCommand(Command):
     user_options = []

--- a/vi3o/__init__.py
+++ b/vi3o/__init__.py
@@ -3,9 +3,6 @@
 ====================================
 """
 
-__version_info__ = (0, 6, 0)
-__version__ = '.'.join(str(i) for i in __version_info__)
-
 # FIXME: Turn into a Video base class that documents the interface
 
 def Video(filename, grey=False):


### PR DESCRIPTION
Due to the package importing vi3o in *setup.py*, the installation requires that **numpy** is present at install time. If you do not have numpy installed, the installation fails.

This commit moves the version from __init__.py to setup.py. If a user
want to see the package version, they can find it by using e.g.

```python
from pkg_resources import get_distribution

__version__ = get_distribution('vi3o').version
```