### PR TITLE
Aggressive try to decode video

### DIFF
--- a/vi3o/__init__.py
+++ b/vi3o/__init__.py
@@ -12,15 +12,20 @@ def Video(filename, grey=False):
     Creates a *Video* object representing the video in the file *filename*.
     See Overview above.
     """
-    if filename.endswith('.mkv'):
-        from vi3o.mkv import Mkv
+    from vi3o.mkv import Mkv, UnsupportedFormatError as MkvUnsupported
+    try:
         return Mkv(filename, grey)
-    elif filename.endswith('.mjpg'):
-        from vi3o.mjpg import Mjpg
+    except MkvUnsupported:
+        pass
+
+    from vi3o.mjpg import Mjpg, UnsupportedFormatError as MjpgUnsupported
+    try:
         return Mjpg(filename, grey)
-    else:
-        from vi3o.imageio import ImageioVideo
-        return ImageioVideo(filename, grey)
+    except MjpgUnsupported:
+        pass
+
+    from vi3o.imageio import ImageioVideo
+    return ImageioVideo(filename, grey)
 
 
 def _get_debug_viewer(name):


### PR DESCRIPTION
Using wget on an Axis camera with e.g. duration or resolution specified creates a file named <something>.mjpg?<param>=<value> which causes the vi3o file type check to fail. This leads to imageio parsing the video but which the Axis time stamps missing.

Files that didn't end with the correct postfix failed to be parsed by
vi3o. In some cases a file was parsed by vi3o if it had one postfix and
silently parsed by imageio if it had another postfix. Instead of
checking the postfix, try to decode and ask for forgivness if failing.