### PR TITLE
Adds method to read an Axis recording

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cffi>=1.2.1
 Pillow>=3.4.2
 numpy
+pytest>=4.6,!=4.6.0
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ import os
 with open(os.path.join(os.path.dirname(__file__), "vi3o", "version.py")) as fp:
     exec(fp.read())
 
+requirements=["cffi>=1.0.0", "numpy>=1.7.1,<1.17"]
+if sys.version_info <= (3, 3, 0):
+    requirements.append("pathlib2")
+
 class PyTestCommand(TestCommand):
     user_options = []
 
@@ -37,7 +41,7 @@ time at the time of capture is provided as timestamp for each frame.
     license='MIT',
     setup_requires=["cffi>=1.0.0"],
     cffi_modules=["build_mjpg.py:ffi", "build_mkv.py:ffi"],
-    install_requires=["cffi>=1.0.0", "numpy>=1.7.1,<1.17"],
+    install_requires=requirements,
     cmdclass={'test': PyTestCommand},
     tests_require=['pytest <= 4.6, !=4.6.0', 'pillow < 7'],
 )

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ time at the time of capture is provided as timestamp for each frame.
     cffi_modules=["build_mjpg.py:ffi", "build_mkv.py:ffi"],
     install_requires=requirements,
     cmdclass={'test': PyTestCommand},
-    tests_require=['pytest <= 4.6, !=4.6.0', 'pillow < 7'],
+    tests_require=['pytest <= 4.6, !=4.6.0', 'pillow < 7', "mock"],
 )

--- a/test/test_cat.py
+++ b/test/test_cat.py
@@ -1,28 +1,14 @@
 # Py2 compat
 from __future__ import unicode_literals, print_function
 
-import itertools
 import os
 import sys
 
 import pytest
 import vi3o
 from vi3o import cat
+from test.util import _FakeVideo, itertools, mock
 
-# Python2 compatibility
-if sys.version_info >= (3, 3, 0):
-    from unittest import mock
-else:
-    import mock
-
-    # Provide an _accumulate function for Py2
-    def _accumulate(vals):
-        retval = 0
-        for val in vals:
-            retval += val
-            yield retval
-
-    itertools.accumulate = _accumulate
 
 
 _LENGTHS = [5, 7, 3]
@@ -39,35 +25,6 @@ _EXPECTED_SYSTIMES = [_BASE_OFFSET + x for x in range(sum(_LENGTHS))]
 # Timestamps should be sequential with 0 offset
 _EXPECTED_TIMESTAMPS = [x for x in range(sum(_LENGTHS))]
 
-
-class _FakeVideo(object):
-    def __init__(self, length):
-        self._length = length
-        # Implementation detail of vi3o.mkv.Mkv
-        self.frame = list((idx * 1.0e6, idx, idx) for idx in range(length))
-
-    def __iter__(self):
-        for idx in range(self._length):
-            obj = mock.MagicMock()
-            obj.timestamp = idx
-            obj.systime = idx
-            yield obj
-
-    @property
-    def systimes(self):
-        return list(range(self._length))
-
-    def __len__(self):
-        return self._length
-
-    def __getitem__(self, idx):
-        if 0 <= idx < self._length:
-            obj = mock.MagicMock()
-            obj.timestamp = idx
-            obj.systime = idx
-            return obj
-
-        raise IndexError
 
 
 @pytest.fixture(scope="function")

--- a/test/test_cat.py
+++ b/test/test_cat.py
@@ -1,13 +1,115 @@
+# Py2 compat
+from __future__ import unicode_literals, print_function
+
+import itertools
 import os
-from vi3o import VideoCat, Video
+import sys
+
+import pytest
+import vi3o
+from vi3o import cat
+
+# Python2 compatibility
+if sys.version_info >= (3, 3, 0):
+    from unittest import mock
+else:
+    import mock
+
+    # Provide an _accumulate function for Py2
+    def _accumulate(vals):
+        retval = 0
+        for val in vals:
+            retval += val
+            yield retval
+
+    itertools.accumulate = _accumulate
+
+
+_LENGTHS = [5, 7, 3]
+_BASE_OFFSET = 15
+
+# Calculate offsets for blocks
+_TIMESTAMP_OFFSETS = [0] + list(itertools.accumulate(_LENGTHS))
+_SYSTIME_OFFSETS = [_BASE_OFFSET + x for x in _TIMESTAMP_OFFSETS]
+
+
+# Systimes should be sequential with an offset
+_EXPECTED_SYSTIMES = [_BASE_OFFSET + x for x in range(sum(_LENGTHS))]
+
+# Timestamps should be sequential with 0 offset
+_EXPECTED_TIMESTAMPS = [x for x in range(sum(_LENGTHS))]
+
+
+class _FakeVideo(object):
+    def __init__(self, length):
+        self._length = length
+        # Implementation detail of vi3o.mkv.Mkv
+        self.frame = list((idx * 1.0e6, idx, idx) for idx in range(length))
+
+    def __iter__(self):
+        for idx in range(self._length):
+            obj = mock.MagicMock()
+            obj.timestamp = idx
+            obj.systime = idx
+            yield obj
+
+    @property
+    def systimes(self):
+        return list(range(self._length))
+
+    def __len__(self):
+        return self._length
+
+    def __getitem__(self, idx):
+        if 0 <= idx < self._length:
+            obj = mock.MagicMock()
+            obj.timestamp = idx
+            obj.systime = idx
+            return obj
+
+        raise IndexError
+
+
+@pytest.fixture(scope="function")
+def mocked_mkv(monkeypatch):
+    # Patch vi3o.mkv with Video object that returns
+    # each of _Fake(l0), _Fake(l1), ..., _Fake(ln)
+    monkeypatch.setattr(
+        vi3o.mkv,
+        "Mkv",
+        mock.Mock(spec=vi3o.mkv.Mkv, side_effect=[_FakeVideo(l) for l in _LENGTHS]),
+    )
+
+
+@pytest.fixture(scope="function")
+def videos(mocked_mkv):
+    return [
+        (vi3o.Video("hello.mkv"), timestamp_offset, systime_offset)
+        for _, timestamp_offset, systime_offset in zip(
+            _LENGTHS, _TIMESTAMP_OFFSETS, _SYSTIME_OFFSETS
+        )
+    ]
+
+
+@pytest.fixture()
+def videocat(videos):
+    return cat.VideoCat(videos)
+
+
+def test_videos_fixture(videos):
+    for (video, _, _), expected_length in zip(videos, _LENGTHS):
+        assert len(video) == expected_length
+    assert len(videos) == len(_LENGTHS)
+
 
 mydir = os.path.dirname(__file__)
-test_mkvs = [os.path.join(mydir, f) for f in ['a.mkv', 'b.mkv', 'c.mkv']]
+test_mkvs = [os.path.join(mydir, f) for f in ["a.mkv", "b.mkv", "c.mkv"]]
+
 
 def test_cat():
-    all_videos = [Video(v) for v in test_mkvs]
+    all_videos = [vi3o.Video(v) for v in test_mkvs]
     frames = sum(len(v) for v in all_videos)
-    video = VideoCat(test_mkvs)
+    video = cat.VideoCat(test_mkvs)
 
     systimes = []
     for fcnt, img in enumerate(video):
@@ -20,7 +122,7 @@ def test_cat():
     assert video[-3].systime == all_videos[-1][-3].systime
 
     index = len(all_videos[0])
-    cut = video[index-2:index+2]
+    cut = video[index - 2 : index + 2]
     assert len(cut) == 4
     assert cut[0].systime == all_videos[0][-2].systime
     assert cut[3].systime == all_videos[1][1].systime
@@ -29,4 +131,111 @@ def test_cat():
     assert cut[3].pts == all_videos[1][1].pts == 60000
 
     assert video.systimes == systimes
-    assert cut.systimes == systimes[index-2:index+2]
+    assert cut.systimes == systimes[index - 2 : index + 2]
+
+
+def test_cat_iterator_raises_on_exhausted(videocat):
+    iterator = iter(videocat)
+    for length in _LENGTHS:
+        for _ in range(length):
+            next(iterator)
+
+    # Now the iterator should be exhausted
+    with pytest.raises(StopIteration):
+        next(iterator)
+
+
+def test_cat_iterator_correct_times(videocat):
+    actual_systimes = []
+    actual_timestamps = []
+    for f in videocat:
+        actual_systimes.append(f.systime)
+        actual_timestamps.append(f.timestamp)
+
+    assert actual_systimes == pytest.approx(_EXPECTED_SYSTIMES)
+    assert actual_timestamps == pytest.approx(_EXPECTED_TIMESTAMPS)
+
+
+def test_cat_correct_systimes(videocat):
+    assert videocat.systimes == pytest.approx(_EXPECTED_SYSTIMES)
+
+
+def test_cat_correct_length(videocat):
+    assert len(videocat) == sum(_LENGTHS)
+
+
+def test_cat_getitem_raises_typeerror(videocat):
+    with pytest.raises(TypeError):
+        _ = videocat["invalid value"]
+
+
+def test_cat_getitem_backward_skipping(videocat):
+    # Skip to block 2
+    frame = videocat[sum(_LENGTHS[:2])]
+    assert frame.systime != pytest.approx(_BASE_OFFSET)
+    # Skip back to block 0
+    frame = videocat[0]
+    assert frame.systime == pytest.approx(_BASE_OFFSET)
+    assert frame.timestamp == pytest.approx(0)
+
+
+def test_cat_getitem_raises_indexerror_on_missing(videocat):
+    with pytest.raises(IndexError):
+        _ = videocat[sum(_LENGTHS)]
+
+    with pytest.raises(IndexError):
+        _ = videocat[-sum(_LENGTHS) - 1]
+
+
+def test_cat_getitem_and_iterator_correspond(videocat):
+    reference = list(videocat)
+    for idx, expected in zip(range(0, sum(_LENGTHS)), reference):
+        assert videocat[idx].systime == pytest.approx(expected.systime)
+        assert videocat[idx].timestamp == pytest.approx(expected.timestamp)
+
+
+def test_cat_getitem_negative_indices(videocat):
+    length = sum(_LENGTHS)
+
+    actual_systimes = list(videocat[idx].systime for idx in range(-length, 0))
+    actual_timestamps = list(videocat[idx].timestamp for idx in range(-length, 0))
+    assert actual_systimes == pytest.approx(_EXPECTED_SYSTIMES)
+    assert actual_timestamps == pytest.approx(_EXPECTED_TIMESTAMPS)
+
+
+def test_cat_getitem_slice_systimes(videocat):
+    my_slice = slice(_LENGTHS[1] - 2, _LENGTHS[2])
+    sliced_values = videocat[my_slice]
+
+    assert sliced_values.systimes == pytest.approx(_EXPECTED_SYSTIMES[my_slice])
+
+
+def test_cat_getitem_slice_values(videocat):
+    my_slice = slice(_LENGTHS[1] - 2, _LENGTHS[2])
+
+    actual_systimes = []
+    actual_timestamps = []
+    for f in videocat[my_slice]:
+        actual_systimes.append(f.systime)
+        actual_timestamps.append(f.timestamp)
+
+    assert actual_systimes == pytest.approx(_EXPECTED_SYSTIMES[my_slice])
+    assert actual_timestamps == pytest.approx(_EXPECTED_TIMESTAMPS[my_slice])
+
+
+def test_cat_raises_on_mjpg():
+    # With offsets it should raise
+    video = mock.MagicMock(spec=vi3o.mjpg.Mjpg)
+    with pytest.raises(NotImplementedError):
+        _ = cat.VideoCat([(video, 0, 0)])
+
+    # But not without
+    _ = cat.VideoCat([video])
+
+
+def test_cat_kwargs_forwarding(monkeypatch):
+    my_mock = mock.MagicMock()
+    monkeypatch.setattr(vi3o, "Video", my_mock)
+    videocat = cat.VideoCat(["hello.mkv"], grey=True)
+    my_mock.assert_called()
+    my_mock.assert_called_with("hello.mkv", grey=True)

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -2,6 +2,7 @@ from vi3o.image import *
 from test.util import TempDir
 import numpy as np
 from py.test import raises
+from vi3o.compat import pathlib
 
 mydir = os.path.dirname(__file__)
 test_jpg = os.path.join(mydir, "00000000.jpg")
@@ -36,6 +37,15 @@ def test_scale():
     img = np.zeros((240, 320), 'B')
     assert imscale(img, 0.5).shape == (120, 160)
     assert imscale(img, (160, 120)).shape == (120, 160)
+
+def test_imsave_and_imread_pathlib():
+    with TempDir() as d:
+        img = np.zeros((320, 240, 3), 'B')
+        img[10, 20] = 255
+        path = pathlib.Path("t1.jpg")
+        imsave(img, path, "jpg")
+        imread(path)
+
 
 def test_imgdir():
     with TempDir() as d:

--- a/test/test_mjpg.py
+++ b/test/test_mjpg.py
@@ -2,6 +2,7 @@ from py.test import raises
 from vi3o.mjpg import Mjpg, jpg_info
 from vi3o.utils import index_file
 import os
+from vi3o.compat import pathlib
 
 mydir = os.path.dirname(__file__)
 test_mjpg = os.path.join(mydir, "t.mjpg")
@@ -42,6 +43,9 @@ def test_idx():
 def test_no_file():
     with raises(IOError):
         Mjpg(test_mjpg + 'not_there')
+
+def test_mjpg_pathlib_open():
+    _ = Mjpg(pathlib.Path(test_mjpg))
 
 def test_slice():
     video = Mjpg(test_mjpg)

--- a/test/test_mkv.py
+++ b/test/test_mkv.py
@@ -8,6 +8,7 @@ import os
 import pickle
 
 from vi3o.utils import index_file
+from vi3o.compat import pathlib
 
 mydir = os.path.dirname(__file__)
 test_mkv = os.path.join(mydir, "t.mkv")
@@ -53,6 +54,9 @@ def test_idx():
 def test_no_file():
     with raises(IOError):
         Mkv(test_mkv + 'not_there')
+
+def test_mkv_pathlib_open():
+    _ = Mkv(pathlib.Path(test_mkv))
 
 def test_slice():
     video = Mkv(test_mkv)

--- a/test/test_recording.py
+++ b/test/test_recording.py
@@ -1,0 +1,236 @@
+""" Test the block stitching logic of Recording """
+from __future__ import unicode_literals, print_function
+
+import itertools
+import sys
+
+import pytest
+import vi3o.compat as compat
+from vi3o import recording
+
+from test.util import _FakeVideo, itertools, mock
+
+# pylint: disable=missing-docstring
+# pylint: disable=redefined-outer-name
+
+_RECORDING_DATA = (
+    '<Recording RecordingToken="20190812_113000_B27F_00408C18823A" >'
+    "<RecordingGroup> </RecordingGroup>"
+    "<SourceToken>4</SourceToken>"
+    "<StartTime>2019-08-12T09:30:00.813188Z</StartTime>"
+    "<StopTime>2019-08-12T09:45:00.945062Z</StopTime>"
+    "<Content></Content>"
+    '<Track TrackToken="Video">'
+    "<VideoAttributes>"
+    "<Width>1920</Width>"
+    "<Height>2160</Height>"
+    "<Framerate>25.00000</Framerate>"
+    "<Framerate_fraction>25:1</Framerate_fraction>"
+    "<Encoding>video/x-h264</Encoding>"
+    "<Bitrate>0</Bitrate>"
+    "</VideoAttributes>"
+    "</Track>"
+    "<Application>AxisCamera</Application>"
+    "<CustomAttributes>"
+    "<TriggerTrigger>Record video</TriggerTrigger>"
+    "<TriggerName>Record</TriggerName>"
+    "<TriggerType>triggered</TriggerType>"
+    "</CustomAttributes>"
+    "</Recording>"
+)
+
+_BLOCK_DATA = (
+    '<RecordingBlock RecordingBlockToken="20190808_141501_32D4" >'
+    "<RecordingToken>20190808_141501_1778_00408C18823D</RecordingToken>"
+    "<StartTime>2019-08-08T12:15:01.338584Z</StartTime>"
+    "<StopTime>2019-08-08T12:20:01.704260Z</StopTime>"
+    "<Status>Complete</Status>"
+    "</RecordingBlock>"
+)
+
+
+
+
+# Note that normally only one type of block exists in a recording
+_BLOCK_XML_FN_A = "derp.xml"
+_BLOCK_MKV_FN_A = "derp.mkv"
+
+_BLOCK_XML_FN_B = "herp.xml"
+_BLOCK_MKV_FN_B = "herp.mkv"
+
+_LENGTHS = [5, 7, 3]
+_BASE_OFFSET = 15
+
+# Calculate offsets for blocks
+_BLOCK_OFFSETS = [
+    _BASE_OFFSET + val for val in ([0] + list(itertools.accumulate(_LENGTHS)))
+]
+
+
+# Systimes should be sequential with an offset
+_EXPECTED_SYSTIMES = [_BASE_OFFSET + x for x in range(sum(_LENGTHS))]
+
+# Timestamps should be sequential with 0 offset
+_EXPECTED_TIMESTAMPS = [x for x in range(sum(_LENGTHS))]
+
+
+@pytest.fixture(scope="function", autouse=True)
+def patched_vi3o(monkeypatch):
+    # Patch vi3o.mkv with Video object that returns
+    # each of _Fake(l0), _Fake(l1), ..., _Fake(ln)
+    monkeypatch.setattr(
+        recording.vi3o.mkv,
+        "Mkv",
+        mock.Mock(side_effect=[_FakeVideo(l) for l in _LENGTHS]),
+    )
+
+
+@pytest.fixture()
+def recording_xml_data(tmp_path):
+    # Generate a believable example with the following layout:
+    #
+    # tmp_path/
+    # |--folder/
+    #    |-- _BLOCK_XML_FN_A
+    #        _BLOCK_MKV_FN_A
+    #  --folder2/
+    #    |-- _BLOCK_XML_FN_B
+    #     -- _BLOCK_MKV_FN_B
+    #  -- recording.xml
+    #
+    # and return the filepaths
+    recording_xml = tmp_path / "recording.xml"
+    recording_xml.write_text(_RECORDING_DATA)
+
+    folder_a = tmp_path / "folder"
+    folder_a.mkdir()
+    xml_a = folder_a / _BLOCK_XML_FN_A
+    video_a = folder_a / _BLOCK_MKV_FN_A
+    xml_a.write_text(_BLOCK_DATA)
+    video_a.write_bytes(b"")
+
+    folder_b = tmp_path / "folder2"
+    folder_b.mkdir()
+    xml_b = folder_b / _BLOCK_XML_FN_B
+    video_b = folder_b / _BLOCK_MKV_FN_B
+    xml_b.write_text(_BLOCK_DATA)
+    video_b.write_bytes(b"")
+    yield recording_xml, xml_a, video_a, xml_b, video_b
+
+
+def test_read_recording_xml_parsing(recording_xml_data):
+    # Test both pathlib and str interface
+    recording_xml, _, _, _, _ = recording_xml_data
+    for path in [recording_xml, str(recording_xml)]:
+        metadata = recording.read_recording_xml(path)
+        # Correct channel parsed
+        assert metadata.channel == 4  # SourceToken
+        # Correct number of blocks discovered
+        assert len(metadata.blocks) == 2
+        # Filename of block is the same as the XML
+        assert _BLOCK_MKV_FN_A in str(metadata.blocks[0].filename)
+        # Alphanumerically ordered blocks
+        assert _BLOCK_MKV_FN_B in str(metadata.blocks[1].filename)
+
+
+@pytest.fixture
+def metadata_missing_blocks():
+    return recording.RecordingMetadata(
+        recording_id="id",
+        channel=0,
+        start=0.0,
+        stop=0.0,
+        width=0,
+        height=0,
+        framerate=25,
+        blocks=[],
+    )
+
+
+@pytest.fixture
+def mocked_metadata(tmp_path):
+    filename = tmp_path / "some_filename.mkv"
+    filename.write_bytes(b"")
+
+    blocks = [
+        recording.RecordingBlock(
+            start=offset, stop=offset + length, filename=filename, status="Complete"
+        )
+        for offset, length in zip(_BLOCK_OFFSETS, _LENGTHS)
+    ]
+    yield recording.RecordingMetadata(
+        recording_id="id",
+        channel=0,
+        start=_BASE_OFFSET,
+        # The end of the video is the last of the block_offsets
+        stop=_BLOCK_OFFSETS[-1],
+        width=0,
+        height=0,
+        framerate=1,
+        blocks=blocks,
+    )
+
+
+def test_read_recoding_xml_raises_on_missing_recording_xml(tmp_path):
+    with pytest.raises(compat.FileNotFoundError):
+        _ = recording.read_recording_xml(tmp_path)
+
+
+def test_read_recording_xml_raises_on_invalid_block(recording_xml_data):
+    recording_xml, xml_a, _, _, _ = recording_xml_data
+    xml_a.write_bytes(b"")
+    with pytest.raises(RuntimeError):
+        recording.read_recording_xml(recording_xml)
+
+
+def test_read_recording_xml_raises_on_missing_video_for_block(recording_xml_data):
+    recording_xml, _, video_a, _, _ = recording_xml_data
+    video_a.unlink()
+    with pytest.raises(compat.FileNotFoundError):
+        _ = recording.read_recording_xml(recording_xml)
+
+
+def test_read_recording_xml_raises_on_incomplete_status(recording_xml_data):
+    recording_xml, xml_a, _, _, _ = recording_xml_data
+
+    xml_a.write_text(_BLOCK_DATA.replace("Complete", "Incomplete"))
+    with pytest.raises(RuntimeError):
+        _ = recording.read_recording_xml(recording_xml)
+
+
+def test_recording_raises_on_mjpg(recording_xml_data):
+    recording_xml, _, video_a, _, _ = recording_xml_data
+
+    # Note: Below is necessary due to pathlib.Path.replace only being available in Python 3.3+
+    video_a.unlink()
+    new_video = video_a.parent / (str(video_a.stem) + ".mjpg")
+    new_video.write_bytes(b"")
+    with pytest.raises(NotImplementedError):
+        _ = recording.Recording(recording.read_recording_xml(recording_xml))
+
+
+def test_recording_raises_on_empty_blocks(metadata_missing_blocks):
+    with pytest.raises(RuntimeError):
+        _ = recording.Recording(metadata_missing_blocks)
+
+
+def test_recording_iterator_correct_times(mocked_metadata):
+    actual_systimes = []
+    actual_timestamps = []
+    for f in recording.Recording(mocked_metadata):
+        actual_systimes.append(f.systime)
+        actual_timestamps.append(f.timestamp)
+
+    assert actual_systimes == pytest.approx(_EXPECTED_SYSTIMES)
+    assert actual_timestamps == pytest.approx(_EXPECTED_TIMESTAMPS)
+
+
+def test_recording_forwards_kwargs(monkeypatch, mocked_metadata):
+    my_mock = mock.MagicMock()
+
+    monkeypatch.setattr(recording.cat, "VideoCat", my_mock)
+
+    _ = recording.Recording(mocked_metadata, grey=True)
+    my_mock.assert_called()
+    _, kwargs = my_mock.call_args
+    assert "grey" in kwargs

--- a/test/util.py
+++ b/test/util.py
@@ -1,9 +1,52 @@
 import tempfile
 import shutil
 from contextlib import contextmanager
+import sys
+
+import itertools
+
+# Python2 compatibility
+if sys.version_info >= (3, 3, 0):
+    import unittest.mock as mock
+else:
+    import mock
+
+    # Provide an _accumulate function for Py2
+    def _accumulate(vals):
+        retval = 0
+        for val in vals:
+            retval += val
+            yield retval
+
+    itertools.accumulate = _accumulate
 
 @contextmanager
 def TempDir():
     temp_dir = tempfile.mkdtemp()
     yield temp_dir
     shutil.rmtree(temp_dir)
+
+class _FakeVideo:
+    def __init__(self, length):
+        self._length = length
+        # Note: 1.0e6 is an implementation detail of vi3o.mkv.Mkv
+        self.frame = list((idx * 1.0e6, idx, idx) for idx in range(length))
+
+    def __iter__(self):
+        for idx in range(self._length):
+            obj = mock.MagicMock()
+            obj.timestamp = idx
+            obj.systime = idx
+            yield obj
+
+    def __len__(self):
+        return self._length
+
+    def __getitem__(self, idx):
+        if 0 <= idx < self._length:
+            obj = mock.MagicMock()
+            obj.timestamp = idx
+            obj.systime = idx
+            return obj
+
+        raise IndexError

--- a/vi3o/__init__.py
+++ b/vi3o/__init__.py
@@ -12,6 +12,9 @@ def Video(filename, grey=False):
     Creates a *Video* object representing the video in the file *filename*.
     See Overview above.
     """
+    # Be compatible with pathlib.Path filenames
+    filename = str(filename)
+
     if filename.endswith('.mkv'):
         from vi3o.mkv import Mkv
         return Mkv(filename, grey)

--- a/vi3o/__init__.py
+++ b/vi3o/__init__.py
@@ -21,6 +21,9 @@ def Video(filename, grey=False):
     elif filename.endswith('.mjpg'):
         from vi3o.mjpg import Mjpg
         return Mjpg(filename, grey)
+    elif filename.endswith('recording.xml'):
+        from vi3o.recording import read_recording_xml, Recording
+        return Recording(read_recording_xml(filename), grey=grey)
     else:
         from vi3o.imageio import ImageioVideo
         return ImageioVideo(filename, grey)

--- a/vi3o/cat.py
+++ b/vi3o/cat.py
@@ -1,6 +1,15 @@
+import collections
 from glob import glob
-from vi3o.utils import SlicedView
-from vi3o import Video
+
+import vi3o
+from vi3o import mjpg
+from vi3o import utils
+from vi3o import compat
+
+_VideoBlock = collections.namedtuple(
+    "_VideoBlock", ["video", "timestamp_offset", "systime_offset"]
+)
+
 
 class VideoCat(object):
     """
@@ -16,38 +25,117 @@ class VideoCat(object):
             ...
 
     """
-    def __init__(self, videos):
-        if not videos:
-            raise AttributeError("VideoCat can't concatinate an empty sequence")
-        self.videos = [Video(v) if isinstance(v, str) else v for v in videos]
 
-    def __iter__(self):
-        fcnt = 0
-        for v in self.videos:
-            for img in v:
-                img.index = fcnt
-                fcnt += 1
-                yield img
+    def __init__(self, videos, **kwargs):
+        self._videos = []
+        self._length = 0
+
+        for values in videos:
+            timestamp_offset, systime_offset = None, None
+
+            try:
+                vid, timestamp_offset, systime_offset = values
+            except ValueError:
+                vid = values
+
+            if isinstance(vid, compat.basestring):
+                vid = vi3o.Video(vid, **kwargs)
+
+            if isinstance(vid, mjpg.Mjpg) and (
+                timestamp_offset is not None or systime_offset is not None
+            ):
+                # TODO: Provide an implementation for mjpg movies that has the same
+                #       behaviour w.r.t systime and timestamp as the Mkv implementation
+                raise NotImplementedError()
+
+            self._length += len(vid)
+            self._videos.append(_VideoBlock(vid, timestamp_offset, systime_offset))
+
+        self._systimes = []  # type: List[float]
+        for blk in self._videos:
+            if blk.systime_offset is None:
+                self._systimes.extend(blk.video.systimes)
+            else:
+                self._systimes.extend(
+                    (
+                        blk_frame[0] / 1.0e6 + blk.systime_offset
+                        for blk_frame in blk.video.frame
+                    )
+                )
 
     def __len__(self):
-        return sum(len(v) for v in self.videos)
+        return self._length
+
+    def __iter__(self):
+        frame_index = 0
+        for blk in self._videos:
+            for frame in blk.video:
+                if blk.systime_offset is not None:
+                    frame.systime = frame.timestamp + blk.systime_offset
+
+                if blk.timestamp_offset is not None:
+                    frame.timestamp += blk.timestamp_offset
+
+                frame.index = frame_index
+                frame_index += 1
+                yield frame
 
     def __getitem__(self, item):
         if isinstance(item, slice):
-            return SlicedView(self, item, {'systimes': self._sliced_systimes})
-        if (item < 0):
-            item += len(self)
-        for v in self.videos:
-            if item < len(v):
-                return v[item]
-            item -= len(v)
+            return utils.SlicedView(self, item, {"systimes": self._sliced_systimes})
+
+        if isinstance(item, int):
+            # Support negative indices
+            if item < 0:
+                item += self._length
+
+            # Quick exit for excessive ranges
+            if not 0 <= item < self._length:
+                raise IndexError
+
+            # Keep track of the requested frame index
+            frame_index = item
+
+            # Find the correct block
+            for blk in self._videos:
+                length = len(blk.video)
+                # Break if the index lies in [previous_length, blk.cumulative_length)
+                if item < length:
+                    break
+                item -= length
+
+            else:
+                # Unreachable
+                raise RuntimeError("Oups")  # pragma: no cover
+
+            # Collect the frame with the correct relative index
+            frame = blk.video[item]  # pylint: disable=undefined-loop-variable
+
+            # Update the systime of the frame
+            if blk.systime_offset is not None:
+                frame.systime = (
+                    frame.timestamp
+                    + blk.systime_offset  # pylint: disable=undefined-loop-variable
+                )
+            if blk.timestamp_offset is not None:
+                frame.timestamp += blk.timestamp_offset
+
+            frame.index = frame_index
+            return frame
+
+        raise TypeError
 
     @property
     def systimes(self):
-        return sum((v.systimes for v in self.videos), [])
+        return self._systimes
 
-    def _sliced_systimes(self, range):
-        return [self.systimes[i] for i in range]
+    def _sliced_systimes(self, range_):
+        return [self._systimes[i] for i in range_]
+
+    @property
+    def videos(self):
+        """ Compatibility method """
+        return [blk.video for blk in self._videos]
 
 
 class VideoGlob(VideoCat):
@@ -56,6 +144,7 @@ class VideoGlob(VideoCat):
     a list of videos. The wildcard is expanded into a list of filenames that is the sorted before
     concatenated.
     """
+
     def __init__(self, pathname):
         videos = glob(pathname)
         videos.sort()

--- a/vi3o/compat.py
+++ b/vi3o/compat.py
@@ -5,7 +5,24 @@ if sys.version_info >= (3, 3, 0):
     import pathlib
 
     basestring = (str, bytes)
+
+    def utc_datetime_to_epoch(dt):  # pylint: disable=invalid-name
+        # Note that the parsed datetime object must be "aware" for datetime.timestamp()
+        # to produce the expected result. This means that we must set the timezone to
+        # UTC explicitly.
+        return dt.replace(tzinfo=datetime.timezone.utc).timestamp()
+
+    FileNotFoundError = FileNotFoundError
 else:
     import pathlib2 as pathlib
 
     basestring = basestring
+
+    def utc_datetime_to_epoch(dt):  # pylint: disable=invalid-name
+        # Keep datetimes naive to avoid any inadvertent time zone conversions
+        return (
+            dt.replace(tzinfo=None) - datetime.datetime(1970, 1, 1)
+        ).total_seconds() + dt.microsecond / 1.0e6
+
+    class FileNotFoundError(OSError):
+        pass

--- a/vi3o/compat.py
+++ b/vi3o/compat.py
@@ -1,0 +1,7 @@
+import sys
+import datetime
+
+if sys.version_info >= (3, 3, 0):
+    import pathlib
+else:
+    import pathlib2 as pathlib

--- a/vi3o/compat.py
+++ b/vi3o/compat.py
@@ -3,5 +3,9 @@ import datetime
 
 if sys.version_info >= (3, 3, 0):
     import pathlib
+
+    basestring = (str, bytes)
 else:
     import pathlib2 as pathlib
+
+    basestring = basestring

--- a/vi3o/image.py
+++ b/vi3o/image.py
@@ -19,6 +19,8 @@ def imsave(img, filename, format=None):
     Save the image *img* into a file named *filename*. If the fileformat is not specified
     in *format*, the filename extension will be used as *format*.
     """
+    # Be compatible with pathlib.Path filenames
+    filename = str(filename)
     if format is None:
         format = filename.split('.')[-1]
     if format == 'jpg':
@@ -42,7 +44,8 @@ def imread(filename, repair=False):
     broken frames, in which case partially decoded frames might be returned. A warning is printed
     to standard output unless *repair* is set to :class:`vi3o.image.Silent`.
     """
-    a =  PIL.Image.open(filename)
+    # Be compatible with pathlib.Path filenames
+    a =  PIL.Image.open(str(filename))
     try:
         a.load()
     except IOError as e:

--- a/vi3o/mjpg.py
+++ b/vi3o/mjpg.py
@@ -14,8 +14,8 @@ class Mjpg(object):
     is returned. It has a few additional format specific properties:
     """
     def __init__(self, filename, grey=False):
-        if sys.version_info > (3,):
-            filename = bytes(filename, "utf8")
+        # Be compatible with pathlib.Path filenames
+        filename = str(filename).encode('utf-8')
         self.filename = filename
         self.grey = grey
         open(filename).close()

--- a/vi3o/mkv.py
+++ b/vi3o/mkv.py
@@ -1,5 +1,5 @@
 import json
-import os, sys
+import os
 from vi3o._mkv import ffi, lib
 from vi3o.utils import SlicedView, index_file, Frame
 from vi3o._mjpg import lib as mjpg_lib
@@ -12,8 +12,8 @@ INDEX_VERSION = 4
 
 class Mkv(object):
     def __init__(self, filename, grey=False, reindex=False):
-        if sys.version_info > (3,):
-            filename = bytes(filename, "utf8")
+        # Be compatible with pathlib.Path filenames
+        filename = str(filename).encode('utf-8')
         self.filename = filename
         self.grey = grey
         open(filename).close()

--- a/vi3o/recording.py
+++ b/vi3o/recording.py
@@ -1,0 +1,184 @@
+"""
+    Interprets the storage format for recordings in AXIS video
+    storage format,  e.g. video stored on a NAS or SD card.
+ """
+from __future__ import unicode_literals, print_function
+import collections
+import datetime
+import sys
+import xml.etree.ElementTree
+
+import vi3o
+from vi3o import mkv
+from vi3o import cat
+from vi3o import compat
+
+if sys.version_info >= (3, 5, 0):
+    from typing import Any, List, Union, Dict
+
+# Representation of data in XML block of a recording
+RecordingBlock = collections.namedtuple(
+    "RecordingBlock", ["start", "stop", "filename", "status"]
+)
+# Representation of data in XML of recording
+RecordingMetadata = collections.namedtuple(
+    "RecordingMetadata",
+    [
+        "recording_id",
+        "channel",
+        "start",
+        "stop",
+        "blocks",
+        "width",
+        "height",
+        "framerate",
+    ],
+)
+
+
+def _parse_axis_xml_timestamp(string):
+    # type: (str) -> float
+    return compat.utc_datetime_to_epoch(
+        datetime.datetime.strptime(string, "%Y-%m-%dT%H:%M:%S.%fZ")
+    )
+
+
+def _read_xml(path):
+    # type: (pathlib.Path) -> Any
+    tree = xml.etree.ElementTree.parse(str(path))
+    return tree.getroot()
+
+
+def _read_recording_block(path):
+    # type: (pathlib.Path) -> RecordingBlock
+    root = _read_xml(path)
+
+    filename = path.parent / (path.stem + ".mkv")
+    if not filename.exists():
+        filename = path.parent / (path.stem + ".mjpg")
+
+    if not filename.exists():
+        raise compat.FileNotFoundError(
+            "Could not find a video file for {}".format(path)
+        )
+
+    status = root.findall(".//Status")[0].text
+    if status != "Complete":
+        raise RuntimeError(
+            '{}: Expected status "Complete", was: "{}"'.format(path, status)
+        )
+
+    return RecordingBlock(
+        start=_parse_axis_xml_timestamp(root.findall(".//StartTime")[0].text),
+        stop=_parse_axis_xml_timestamp(root.findall(".//StopTime")[0].text),
+        status=status,
+        filename=filename,
+    )
+
+
+def read_recording_xml(recording_xml):
+    # type: (Union[str,pathlib.Path]) -> RecordingMetadata
+    """
+        Read metadata from an Axis recording from e.g. a SD card or a NAS
+
+        .. code-block:: python
+
+            import vi3o
+
+            metadata = vi3o.read_recording_xml("/path/to/recording.xml")
+            print("Width: {}, Height: {}".format(metadata.width, metadata.height))
+            print("Number of blocks: {}".format(len(metadata.blocks)))
+    """
+    if isinstance(recording_xml, str):
+        recording_xml = compat.pathlib.Path(recording_xml)
+
+    if not recording_xml.is_file():
+        raise compat.FileNotFoundError("recording.xml must be a file")
+
+    root = _read_xml(recording_xml)
+
+    try:
+        blocks = []
+        for pth in recording_xml.parent.glob("*/*.xml"):
+            blocks.append(_read_recording_block(pth))
+
+    except (ValueError, xml.etree.ElementTree.ParseError) as error:
+        raise RuntimeError("Failure parsing block {}: {}".format(pth, error))
+    blocks.sort()
+
+    return RecordingMetadata(
+        recording_id=root.attrib["RecordingToken"],
+        channel=int(root.findall(".//SourceToken")[0].text),
+        start=_parse_axis_xml_timestamp(root.findall(".//StartTime")[0].text),
+        stop=_parse_axis_xml_timestamp(root.findall(".//StopTime")[0].text),
+        width=int(root.findall(".//Width")[0].text),
+        height=int(root.findall(".//Height")[0].text),
+        framerate=float(root.findall(".//Framerate")[0].text),
+        blocks=tuple(blocks),
+    )
+
+
+class Recording(object):
+    """
+        Load video from a folder containing a Axis recording from e.g.
+        a SD card or a NAS
+
+        Axis stores videos in a blocked format together with XML metadata.
+        The XML metadata contains time information which may be used to
+        deduce the wall time of the recordings should the video streams
+        themselves lack the proper metadata.
+
+        Either use the convenience method `vi3o.Video`
+
+        .. code-block:: python
+
+            import vi3o
+            recording = vi3o.Video("/path/to/recording.xml")
+
+        Or load metadata manually using `read_recording_xml`
+
+        .. code-block:: python
+
+            import vi3o
+            metadata = vi3o.read_recording_xml("/path/to/recording.xml")
+            recording = Recording(metadata)
+
+
+    """
+
+    def __init__(self, metadata, **kwargs):
+        if not metadata.blocks:
+            raise RuntimeError("No recordings discovered!")
+
+        # Preprocessing of all video blocks in folder - this may take some time...
+        videos = []  # type: List[_VideoBlock]
+        timestamp_offset = 0
+        for blk in metadata.blocks:
+            # Note: Video raises OSError if file was not found
+            filename = str(blk.filename)
+            videos.append(
+                cat._VideoBlock(
+                    video=filename,
+                    timestamp_offset=timestamp_offset,
+                    systime_offset=blk.start,
+                )
+            )
+            # The first frame in the next block will start at timestamp offset
+            timestamp_offset += blk.stop - blk.start
+
+        self._video = cat.VideoCat(videos, **kwargs)
+
+    def __len__(self):
+        return len(self._video)
+
+    @property
+    def systimes(self):
+        # type: () -> List[float]
+        """ Return the systimes of all frames in recording """
+        return self._video.systimes
+
+    def __iter__(self):
+        return iter(self._video)
+
+    def __getitem__(self, item):
+        return self._video[item]


### PR DESCRIPTION
..from an Axis camera typically stored on a SD card or a NAS.

Such a recording is usually stored in a folder hierarchy:

axis-<device_mac>
|-<date>
|--<hour>
|---<date>_<time>_<recording_id>
|----recording.xml
|-----<date>_<time>
|------<date>_<time>_<block_id>.xml
|------<date>_<time>_<block_id>.mkv

This commit provides a method that reads the metadata in the
associated XML-files of such a recording to:

 * Provide a single interface to the video that may be chunked
   over serveral files.

 * Argument the video with the systimes provided in the
   metadata, which are always available in contrast to
   headers in the video stream that may or may not be present.

 * A convenience method in `vi3o.Video` that automatically
   generates a Recording object when a filename ending with
   `recording.xml` is provided.