### PR TITLE
Repair AxisCam (imwrite fp interface)

### DIFF
--- a/test/test_cat.py
+++ b/test/test_cat.py
@@ -194,5 +194,5 @@ def test_cat_kwargs_forwarding(monkeypatch):
     my_mock = mock.MagicMock()
     monkeypatch.setattr(vi3o, "Video", my_mock)
     videocat = cat.VideoCat(["hello.mkv"], grey=True)
-    my_mock.assert_called()
+    assert my_mock.called
     my_mock.assert_called_with("hello.mkv", grey=True)

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -3,6 +3,7 @@ from test.util import TempDir
 import numpy as np
 from py.test import raises
 from vi3o.compat import pathlib
+import io
 
 mydir = os.path.dirname(__file__)
 test_jpg = os.path.join(mydir, "00000000.jpg")
@@ -107,3 +108,21 @@ def test_imread():
     img = imread(test_jpg2, True)
     assert isinstance(img, np.ndarray)
     assert img.shape == (240, 320, 3)
+
+def test_imread_open_file():
+    img = imread(open(test_jpg, "rb"))
+    assert isinstance(img, np.ndarray)
+    assert img.shape == (288, 360)
+
+def test_imread_bytesio():
+    bytesio = io.BytesIO(open(test_jpg, "rb").read())
+    img = imread(bytesio)
+    assert isinstance(img, np.ndarray)
+    assert img.shape == (288, 360)
+
+def test_imsave_bytesio():
+    bytesio = io.BytesIO()
+    imsave(np.zeros((10,10), dtype=np.uint8), bytesio, format="jpg")
+    print(bytesio.getvalue())
+    assert b"\xff\xd8" in bytesio.getvalue()  # Start of image
+    assert b"\xff\xd9" in bytesio.getvalue()  # end of image

--- a/test/test_recording.py
+++ b/test/test_recording.py
@@ -231,6 +231,6 @@ def test_recording_forwards_kwargs(monkeypatch, mocked_metadata):
     monkeypatch.setattr(recording.cat, "VideoCat", my_mock)
 
     _ = recording.Recording(mocked_metadata, grey=True)
-    my_mock.assert_called()
+    assert my_mock.called
     _, kwargs = my_mock.call_args
     assert "grey" in kwargs

--- a/vi3o/image.py
+++ b/vi3o/image.py
@@ -20,15 +20,18 @@ def imsave(img, filename, format=None):
     Save the image *img* into a file named *filename*. If the fileformat is not specified
     in *format*, the filename extension will be used as *format*.
     """
-    # Be compatible with pathlib.Path filenames
-    filename = str(filename)
     if format is None:
         format = filename.split('.')[-1]
     if format == 'jpg':
         format = 'jpeg'
     if img.dtype != 'B':
         img = np.minimum(np.maximum(img, 0), 255).astype('B')
-    PIL.Image.fromarray(img).save(filename, format.lower())
+    try:
+        # filename might be an open file
+        PIL.Image.fromarray(img).save(filename, format.lower())
+    except AttributeError:
+        # Try converting filename to a string to handle e.g. patlib2 paths
+        PIL.Image.fromarray(img).save(str(filename), format.lower())
 
 def imsavesc(img, filename, format=None):
     """
@@ -45,8 +48,12 @@ def imread(filename, repair=False):
     broken frames, in which case partially decoded frames might be returned. A warning is printed
     to standard output unless *repair* is set to :class:`vi3o.image.Silent`.
     """
-    # Be compatible with pathlib.Path filenames
-    a =  PIL.Image.open(str(filename))
+    try:
+        # filename might be an open file
+        a =  PIL.Image.open(filename)
+    except AttributeError:
+        # Try converting filename to a string to handle e.g. patlib2 paths
+        a =  PIL.Image.open(str(filename))
     pillow_truncated_img = PIL.ImageFile.LOAD_TRUNCATED_IMAGES
     try:
         PIL.ImageFile.LOAD_TRUNCATED_IMAGES = False

--- a/vi3o/image.py
+++ b/vi3o/image.py
@@ -4,6 +4,7 @@
 """
 
 import PIL.Image
+import PIL.ImageFile
 import numpy as np
 import os
 from vi3o import view
@@ -46,13 +47,19 @@ def imread(filename, repair=False):
     """
     # Be compatible with pathlib.Path filenames
     a =  PIL.Image.open(str(filename))
+    pillow_truncated_img = PIL.ImageFile.LOAD_TRUNCATED_IMAGES
     try:
+        PIL.ImageFile.LOAD_TRUNCATED_IMAGES = False
         a.load()
     except IOError as e:
         if not repair:
             raise
         if repair is not Silent:
             print("Warning: IOError while reading '%s': %s" % (filename, e))
+        PIL.ImageFile.LOAD_TRUNCATED_IMAGES = True  # Allow partial decode if truncated images
+        a.load()
+    finally:
+        PIL.ImageFile.LOAD_TRUNCATED_IMAGES = pillow_truncated_img
     return np.array(a)
 
 


### PR DESCRIPTION
Usage of vi3o.image.imwrite with open file descriptors was changed in
an earlier commit aiming to make vi3o compatible with pathlib. Since
pillow has been pathlib compatible since version 3 the string conversion
is not needed. This commit makes the vi3o.netcam.AxisCam class work
again.