### PR TITLE
Repair tests for python 3-3.5

### DIFF
--- a/test/test_cat.py
+++ b/test/test_cat.py
@@ -194,5 +194,5 @@ def test_cat_kwargs_forwarding(monkeypatch):
     my_mock = mock.MagicMock()
     monkeypatch.setattr(vi3o, "Video", my_mock)
     videocat = cat.VideoCat(["hello.mkv"], grey=True)
-    my_mock.assert_called()
+    assert my_mock.called
     my_mock.assert_called_with("hello.mkv", grey=True)

--- a/test/test_recording.py
+++ b/test/test_recording.py
@@ -231,6 +231,6 @@ def test_recording_forwards_kwargs(monkeypatch, mocked_metadata):
     monkeypatch.setattr(recording.cat, "VideoCat", my_mock)
 
     _ = recording.Recording(mocked_metadata, grey=True)
-    my_mock.assert_called()
+    assert my_mock.called
     _, kwargs = my_mock.call_args
     assert "grey" in kwargs

--- a/vi3o/image.py
+++ b/vi3o/image.py
@@ -4,6 +4,7 @@
 """
 
 import PIL.Image
+import PIL.ImageFile
 import numpy as np
 import os
 from vi3o import view
@@ -46,13 +47,19 @@ def imread(filename, repair=False):
     """
     # Be compatible with pathlib.Path filenames
     a =  PIL.Image.open(str(filename))
+    pillow_truncated_img = PIL.ImageFile.LOAD_TRUNCATED_IMAGES
     try:
+        PIL.ImageFile.LOAD_TRUNCATED_IMAGES = False
         a.load()
     except IOError as e:
         if not repair:
             raise
         if repair is not Silent:
             print("Warning: IOError while reading '%s': %s" % (filename, e))
+        PIL.ImageFile.LOAD_TRUNCATED_IMAGES = True  # Allow partial decode if truncated images
+        a.load()
+    finally:
+        PIL.ImageFile.LOAD_TRUNCATED_IMAGES = pillow_truncated_img
     return np.array(a)
 
 


### PR DESCRIPTION
In the test Mock.assert_called() was used, this was new in python 3.6
and thus made the tests fail for e.g. python3.5