### PR TITLE
Fix pillow > 6.1.1 compatibility bug with bad img

### DIFF
--- a/vi3o/image.py
+++ b/vi3o/image.py
@@ -4,6 +4,7 @@
 """
 
 import PIL.Image
+import PIL.ImageFile
 import numpy as np
 import os
 from vi3o import view
@@ -46,13 +47,19 @@ def imread(filename, repair=False):
     """
     # Be compatible with pathlib.Path filenames
     a =  PIL.Image.open(str(filename))
+    pillow_truncated_img = PIL.ImageFile.LOAD_TRUNCATED_IMAGES
     try:
+        PIL.ImageFile.LOAD_TRUNCATED_IMAGES = False
         a.load()
     except IOError as e:
         if not repair:
             raise
         if repair is not Silent:
             print("Warning: IOError while reading '%s': %s" % (filename, e))
+        PIL.ImageFile.LOAD_TRUNCATED_IMAGES = True  # Allow partial decode if truncated images
+        a.load()
+    finally:
+        PIL.ImageFile.LOAD_TRUNCATED_IMAGES = pillow_truncated_img
     return np.array(a)
 
 


### PR DESCRIPTION
The vi3o.image.imread function has a repair flag which purpose is to
allow partial decode of truncated images. This functionality is expected
to work only if the PIL.ImageFile.LOAD_TRUNCATED_IMAGES flag is set
which is was not. However up to version 6.1.0 of pillow there was a bug
which made pillow only complain the first time a decode was tried. Since
our implementation first does an explicit load (a.load(), which raises
an error and results in an empty array) and then does an second implicit
load (called from within np.array(a)) the partial image data was
retrieved "by luck". This is covered by the unit tests, so unit tests
will fail if using pillow>6.1.1.

This commit fixes the issue to get the same behaviour with new pillow
versions by setting the global LOAD_TRUNCATED_IMAGES flag to the desired
state and finally restoring the flag to its prior state.