### PR TITLE
Fixes race in index_file creation

### DIFF
--- a/vi3o/utils.py
+++ b/vi3o/utils.py
@@ -42,6 +42,8 @@ def index_file(fn, extradata=None):
     key = hashlib.md5(key.encode()).hexdigest()
     path = os.path.join(cache_dir, key + '.idx')
     d = os.path.dirname(path)
-    if not os.path.exists(d):
+    try:
         os.makedirs(d)
+    except OSError:
+        pass
     return path


### PR DESCRIPTION
When launching multiple processes of vi3o, it is possible for a
race to trigger in the creation of the cache folder.

This commit addresses said race condition, by asking for forgiveness
w.r.t. the folder creation.

Solves: #19