### PR TITLE
Adds VideoFilter class to modify frames

### DIFF
--- a/test/test_video_filter.py
+++ b/test/test_video_filter.py
@@ -1,0 +1,163 @@
+from py.test import raises
+import vi3o
+from vi3o.mjpg import Mjpg
+from vi3o.mkv import Mkv
+from vi3o.utils import VideoFilter, Frame
+from test.util import mock
+import numpy as np
+import os
+
+mydir = os.path.dirname(__file__)
+test_mjpg = os.path.join(mydir, "t.mjpg")
+systime_mkv = os.path.join(mydir, "systime.mkv")
+
+def test_slice_not_implemented_systime():
+    """Systimes property not implemented for all videos
+
+    propagate this correctly, but do allow slices..
+    """
+    class Dummy(mock.MagicMock):
+        @property
+        def systimes(self):
+            raise NotImplementedError()
+    video_mock = Dummy(spec_set=Mjpg)
+    video_mock.__len__.return_value = 10
+    video = VideoFilter(video_mock, lambda f: f[:])
+    with raises(NotImplementedError):
+        _ = video.systimes
+    cut = video[2:4]
+    assert len(cut) == 2
+    with raises(NotImplementedError):
+        _ = cut.systimes
+
+def test_slice_implemented_systime():
+    """Systimes property should follow a slice
+    """
+    video_mock = mock.MagicMock(spec_set=Mjpg)
+    video_mock.__len__.return_value = 4
+    video_mock.systimes = [1, 2, 4, 10]
+    video = VideoFilter(video_mock, lambda f: f[:])
+    assert video.systimes == [1, 2, 4, 10]
+    cut = video[1:3]
+    assert cut.systimes == [2, 4]
+
+def test_iter():
+    timestamps = []
+    pixels = []
+    video = VideoFilter(Mjpg(test_mjpg), lambda f: f[:50,:50])
+    for i, img in enumerate(video):
+        assert img.index == i
+        timestamps.append(img.timestamp)
+        assert img.timestamp == img.systime
+        pixels.append(img[20,30,1])
+    assert len(timestamps) == 16
+    assert timestamps[1] == 1445859308.97
+    assert pixels[:7] == [84, 83, 84, 86, 86, 84, 84]
+
+    assert video[1].timestamp == 1445859308.97
+    assert video[2].index == 2
+    assert video[0][20,30,1] == 84
+    assert len(video)== 16
+    with raises(IndexError):
+        video[100]
+
+@mock.patch.object(vi3o, 'Video')
+def test_no_file(video_mock):
+    def raise_error(filename, **kwargs):
+        raise IOError("Mock error for %s" % filename)
+
+    video_mock.side_effect = raise_error
+    with raises(IOError):
+        VideoFilter("dummy", lambda f: f)
+
+def test_slice():
+    video = VideoFilter(Mjpg(test_mjpg), lambda f: f)
+    sub = video[2:5]
+    assert [img[20,30,1] for img in sub] == [84, 86, 86]
+    assert sub[1].timestamp == video[3].timestamp
+    assert len(sub) == 3
+
+def test_grey():
+    video = VideoFilter(Mjpg(test_mjpg, grey=True), lambda f: f)
+    for img in video:
+        assert img.shape == (120, 160)
+
+    video = VideoFilter(Mjpg(test_mjpg, grey=True), lambda f: f[:f.shape[0]//2])
+    for img in video:
+        assert img.shape == (60, 160)
+
+def test_open_by_fname():
+    video = VideoFilter(str(test_mjpg), lambda f: f)
+    assert video[0].shape == (120, 160, 3)
+
+def test_change_metadata():
+    def offset_time(frame):
+        frame.systime += 3600
+        return frame
+
+    pixels = []
+    video1 = Mjpg(test_mjpg)
+    video2 = VideoFilter(video1, offset_time)
+    for img, img_filtered in zip(video1, video2):
+        assert img.systime == img_filtered.systime - 3600
+        assert img.timestamp == img_filtered.timestamp
+        assert np.all(img[:7] == img_filtered[:7])
+
+def test_change_metadata_on_copy():
+    def offset_time(org_frame):
+        frame = org_frame[:]
+        frame.systime = org_frame.systime + 3600
+        return frame
+
+    pixels = []
+    video1 = Mjpg(test_mjpg)
+    video2 = VideoFilter(video1, offset_time)
+    for img, img_filtered in zip(video1, video2):
+        assert img.systime == img_filtered.systime - 3600
+        assert img.timestamp == img_filtered.timestamp
+        assert np.all(img[:7] == img_filtered[:7])
+
+def test_mkv_systime():
+    video = VideoFilter(Mkv(systime_mkv), lambda f: f[:])
+    assert video[7].systime == 1448984844.6525
+    t = [img.systime for img in video]
+    assert t == video.systimes
+
+    cut = video[10:20]
+    assert t[10:20] == cut.systimes
+
+def test_mkv_getitem():
+    video = VideoFilter(Mkv(systime_mkv), lambda f: f[:])
+    idx = 31
+    for i in range(3):
+        assert video[idx-1].index == idx-1
+    for i in range(3):
+        assert video[idx].index == idx
+    for i in range(3):
+        assert video[idx+1].index == idx+1
+
+def _get_np_pointer(arr):
+    return arr.__array_interface__["data"][0]
+
+@mock.patch.object(vi3o, "Video")
+def test_no_copy_filter(mocked_video):
+    def filter_func(img):
+        return img
+
+    frm = Mjpg(test_mjpg)[0]
+    mocked_video.return_value = [frm]
+    
+    video = VideoFilter("dummy", filter_func)
+    assert _get_np_pointer(video[0]) == _get_np_pointer(frm)
+
+@mock.patch.object(vi3o, "Video")
+def test_copy_filter(mocked_video):
+    def filter_func(img):
+        return img.copy()
+
+    frm = Mjpg(test_mjpg)[0]
+    mocked_video.return_value = [frm]
+
+    video = VideoFilter("dummy", filter_func)
+    assert _get_np_pointer(video[0]) != _get_np_pointer(frm)
+    assert video[0].timestamp == frm.timestamp

--- a/vi3o/utils.py
+++ b/vi3o/utils.py
@@ -1,5 +1,7 @@
 import sys, os, hashlib
 import numpy as np
+import vi3o
+from vi3o import compat
 
 if sys.version_info > (3,):
     xrange = range
@@ -33,6 +35,80 @@ class SlicedView(object):
         self.__dict__.update(state)
         self.properties = ()
 
+class VideoFilter:
+    """Apply a filter on the output frames from a video
+
+    VideoFilter objects can be used as regular vi3o videos but applies a filter to
+    the Frame object when iterating or accessing it.
+
+    E.g, create a video that only is using the top half of the frames:
+
+        .. code-block:: python
+
+            video = VideoFilter(fname, lambda frame: frame[:frame.shape[0]//2])
+
+    E.g. offset the timestamp of each frame by one hour:
+
+        .. code-block:: python
+
+            def offset_time(frame):
+                frame.systime += 3600
+                return frame
+
+            video = VideoFilter(fname, offset_time)
+    """
+
+    def __init__(self, video, filter_function, **kwargs):
+        if isinstance(video, compat.basestring):
+            video = vi3o.Video(video, **kwargs)
+        self.video = video
+        self.filter_function = filter_function
+
+    def _sliced_systimes(self, range):
+        """Systimes property might not be implemented, depends on base video class
+        """
+        return [self.systimes[i] for i in range]
+
+    def __iter__(self):
+        for f in self.video:
+            yield self._filter(f)
+
+    def __len__(self):
+        return len(self.video)
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            try:
+                return SlicedView(self, item, {"systimes": self._sliced_systimes})
+            except AttributeError:
+                return SlicedView(self, item)
+        return self._filter(self.video[item])
+
+    def __getattr__(self, name):
+        return getattr(self.video, name)
+
+    def _filter(self, org_frame):
+        img = self.filter_function(org_frame)
+        frame = copy_missing_metadata(img, org_frame)
+        return frame
+
+def copy_missing_metadata(dst_img, template_frame):
+    """Copy missing meta data from template Frame object
+    """
+    def try_set_attribute(frame, attribute):
+        # Try first to keep from the input image
+        if hasattr(dst_img, attribute):
+            setattr(frame, attribute, getattr(dst_img, attribute))
+            return
+        # Try to copy from the template frame
+        # properties for meta data might differ with video type...
+        if hasattr(template_frame, attribute):
+            setattr(frame, attribute, getattr(template_frame, attribute))
+            
+    dst_frame = dst_img.view(Frame)
+    for attribute in ("timestamp", "systime", "pts", "index"):
+        try_set_attribute(dst_frame, attribute)
+    return dst_frame
 
 cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "vi3o")
 


### PR DESCRIPTION
Using this class a video object can be initiated with a frame filter and
then be used as a regular vi3o video object. We could e.g. choose to
only use the top half of the image by creating the video with:

video = VideoFilter(fname, lambda frame: frame[:frame.shape[0]//2])

The frame meta data can also be modified from the filter function by
disabling the default copying of meta data:

def offset_time(frame):
    frame.systime += 3600
    return frame

video = VideoFilter(fname, offset_time, copy_frame_meta=False)

This class helps to avoid propagating information about e.g. crop
together with the video through the whole codebase. It is compatible
with SyncedVideos and works with both Mjpg and Mkv video. It can also be
used recursively with itself. It does add some copies of each frame and
should thus be avoided for high frame rate processing if CPU or memory
bandwith is a bottleneck.

Change-Id: I6341ff36151ca744a25223e81990a39a13ba325c