### PR TITLE
Enables numpy>=1.17 for py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,13 @@ import os
 with open(os.path.join(os.path.dirname(__file__), "vi3o", "version.py")) as fp:
     exec(fp.read())
 
-requirements=["cffi>=1.0.0", "numpy>=1.7.1,<1.17"]
+requirements=["cffi>=1.0.0"]
+
+if sys.version_info < (3,):
+    requirements.append("numpy>=1.7.1,<1.17")
+else:
+    requirements.append("numpy>=1.7.1")
+
 if sys.version_info <= (3, 3, 0):
     requirements.append("pathlib2")
 


### PR DESCRIPTION
The problem that numpy>1.17 does not support py2 need not affect deployments using py3.
In fact, this becomes problem when trying to use vi3o in an environment that overlaps
with openembedded where the version of numpy was recently bumped to 1.17.4.