### PR TITLE
Expose Axis camera MAC in Mkv video

### DIFF
--- a/test/test_mkv.py
+++ b/test/test_mkv.py
@@ -14,6 +14,7 @@ mydir = os.path.dirname(__file__)
 test_mkv = os.path.join(mydir, "t.mkv")
 systime_mkv = os.path.join(mydir, "systime.mkv")
 mjpg_codec_mkv = os.path.join(mydir, "test_mjpg_codec.mkv")
+mac_mkv = os.path.join(mydir, "c.mkv")
 
 def test_iter():
     timestamps = []
@@ -128,3 +129,9 @@ def test_mjpg_codec_grey():
         systimes.append(img.systime)
         assert img.shape == (300, 480)
     assert systimes == [1539001990.82, 1539001991.82, 1539001992.82]
+
+def test_serial_number():
+    assert Mkv(mac_mkv).serial_number == b'ACCC8E19244E'
+
+def test_no_serial_number():
+    assert Mkv(test_mkv).serial_number == b''

--- a/vi3o/mkv.py
+++ b/vi3o/mkv.py
@@ -61,6 +61,14 @@ class Mkv(object):
     def _sliced_systimes(self, range):
         return [self.systimes[i] for i in range]
 
+    @property
+    def serial_number(self):
+        """
+        The Axis serial number or mac address of the camera that made this recording.
+        """
+        self.myiter.next()
+        return ffi.string(self.myiter.m.mac)
+
     def __iter__(self):
         return MkvIter(self.filename, self.systime_offset, self.grey)
 


### PR DESCRIPTION
This is parsed in the mkv parser but is not exposed in the python
wrapper. In the Mjpg wrapper we expose hwid, serial_number and
firmware_version but of these three we only have the serial number (MAC)
in the Mkv data.

Change-Id: Icdaee0f2fe06d995402ad92c7378577f94c87ab2