### PR TITLE
Fix length property of mp4 video

### DIFF
--- a/test/test_ffprobe.py
+++ b/test/test_ffprobe.py
@@ -1,0 +1,38 @@
+from py.test import raises
+
+import os
+from vi3o.ffprobe import FFProbe, FFProbeException
+from vi3o.compat import pathlib
+
+mydir = os.path.dirname(__file__)
+test_mkv = os.path.join(mydir, "a.mkv")
+
+
+def test_ffprobe():
+    probe = FFProbe(test_mkv)
+    assert len(probe.video) == 1
+    assert len(probe.audio) == 0
+
+    stream = probe.video[0]
+    assert stream.codec_name == "h264"
+    assert stream.pixel_format == "yuvj420p"
+    assert stream.frame_size == (600, 800)
+    assert stream.language == "eng"
+
+    # 'Unsafe' fields does not have conversion, they are
+    # raw from ffprobe:
+    assert stream._width == '800'
+    assert stream._height == '600'
+
+    # Some fields like 'frames' is not available in
+    # mkv video using ffprobe. We should add another
+    # test video with mp4 format where we can test these
+    # fields.
+    with raises(FFProbeException):
+        stream.frames
+
+
+def test_ffprobe_no_such_file():
+    test_path = os.path.join(mydir, "no_such_file.mp4")
+    with raises(FileNotFoundError):
+        FFProbe(test_path)

--- a/test/test_ffprobe.py
+++ b/test/test_ffprobe.py
@@ -3,6 +3,7 @@ from py.test import raises
 import os
 from vi3o.ffprobe import FFProbe, FFProbeException
 from vi3o.compat import pathlib
+from vi3o.imageio import ImageioVideo
 
 mydir = os.path.dirname(__file__)
 test_mkv = os.path.join(mydir, "a.mkv")
@@ -36,3 +37,20 @@ def test_ffprobe_no_such_file():
     test_path = os.path.join(mydir, "no_such_file.mp4")
     with raises(FileNotFoundError):
         FFProbe(test_path)
+
+
+def test_imageio():
+    v = ImageioVideo(test_mkv)
+
+    # imageio ffmpeg can't find the length of the mkv video,
+    # neither can ffprobe. This will fall back to the frame
+    # counting method.
+
+    # TODO: Decoding the video with the c implementation of the
+    # mkv parser gives 1136 frames in video, decoding with
+    # imageio-ffmpeg gives 1159 frames in video. All frames
+    # seems OK visualy. Values in the frame does however differ
+    # in all frames already from the start. Leaving this check
+    # as is for now since the decoding issue is not related to
+    # the frame counting issue.
+    assert len(v) == 1159

--- a/vi3o/ffprobe.py
+++ b/vi3o/ffprobe.py
@@ -1,0 +1,222 @@
+"""
+The following is a modified (and modernized to deal with python3) version of ffprobe.py from https://pypi.org/project/ffprobe/.
+Unfortunately that project has not been maintained since 2013. It was/is distributed under an MIT license.
+
+The following code is based on release 0.5 / Oct 30, 2013
+"""
+import subprocess
+import re
+from vi3o.compat import pathlib
+import os
+
+
+class FFProbeException(Exception):
+    pass
+
+
+class FFProbe:
+    """ffprobe reader for video files
+
+    OBS! This class assumes that ffprobe binary is found in your path,
+    be careful when using this class that it might not always be the
+    case..
+    """
+    def __init__(self, video_file):
+        video_file = pathlib.Path(video_file)
+        self.verify_binary()
+
+        if not video_file.exists():
+            raise FileNotFoundError('No such media file %s' % str(video_file))
+
+        self.format = None
+        self.created = None
+        self.duration = None
+        self.start = None
+        self.bitrate = None
+        self.streams = []
+        self.video = []
+        self.audio = []
+        datalines = []
+
+        proc = subprocess.Popen(
+                ["ffprobe -show_streams %s" % str(video_file)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=True
+        )
+
+        self._parse_output(proc)
+        self._reference_streams()
+
+        proc.stdout.close()
+        proc.stderr.close()
+
+    def _parse_output(self, proc):
+        """Read all the output lines and store each stream meta data
+
+        The output will print the info for all streams separated with the
+        [STREAM] and [/STREAM] markers. Parse the lines in between them and
+        store each as an FFStream object in the self.streams list.
+        """
+        for line in iter(proc.stdout.readline, b''):
+            if re.match(b'\[STREAM\]', line):
+                datalines=[]
+            elif re.match(b'\[\/STREAM\]', line):
+                self.streams.append(FFStream(datalines))
+                datalines=[]
+            else:
+                datalines.append(line.decode("utf-8"))
+
+    def _reference_streams(self):
+        """Set the video and audio streams
+        """
+        for stream in self.streams:
+            if stream.is_audio:
+                self.audio.append(stream)
+            if stream.is_video:
+                self.video.append(stream)
+
+    def verify_binary(self):
+        try:
+            with open(os.devnull, 'w') as tempf:
+                subprocess.check_call(["ffprobe","-h"], stdout=tempf, stderr=tempf)
+        except OSError:
+            raise IOError('ffprobe command not found in PATH.')
+
+
+class FFStream:
+    """
+    An object representation of an individual stream in a multimedia file.
+    """
+    def __init__(self, datalines):
+        # Add each key value pair to the object dict so that they
+        # are directly accessable without implementing getter functions.
+        # This allows us to reflect all fields from ffprobe with no
+        # knowledge of them, but on the other hand with no error checking
+        # or format conversion. Thus we prefix with underscore.
+        for line in datalines:
+            (key, val) = line.strip().split('=')
+            self.__dict__["_%s" % key] = val
+
+        # Some fields that are strings can be marked as safe:
+        safe = [
+                "codec_name",
+                "codec_long_name",
+                "pix_fmt",
+        ]
+        for key in safe:
+            self.__dict__[key] = self.__dict__.get("_%s" % key)
+
+    @property
+    def is_audio(self):
+        """
+        Is this stream labelled as an audio stream?
+        """
+        val=False
+        if self.__dict__['_codec_type']:
+            if str(self.__dict__['_codec_type']) == 'audio':
+                val=True
+        return val
+
+    @property
+    def is_video(self):
+        """
+        Is the stream labelled as a video stream.
+        """
+        val=False
+        if self.__dict__['_codec_type']:
+            if self._codec_type == 'video':
+                val=True
+        return val
+
+    @property
+    def is_subtitle(self):
+        """
+        Is the stream labelled as a subtitle stream.
+        """
+        val=False
+        if self.__dict__['_codec_type']:
+            if str(self._codec_type)=='subtitle':
+                val=True
+        return val
+
+    @property
+    def frame_size(self):
+        """
+        Returns the pixel frame size as an integer tuple (height, width) if the stream is a video stream.
+        Returns None if it is not a video stream.
+        """
+        size=None
+        if self.is_video:
+            h = self.__dict__['_height']
+            w = self.__dict__['_width']
+            if h and w:
+                try:
+                    size=(int(h), int(w))
+                except ValueError:
+                    raise FFProbeException("None integer size %s:%s" %(str(h), str(w)))
+        return size
+
+    @property
+    def pixel_format(self):
+        """
+        Returns a string representing the pixel format of the video stream. e.g. yuv420p.
+        Returns none is it is not a video stream.
+        """
+        f=None
+        if self.is_video:
+            if self.__dict__['pix_fmt']:
+                f=self.__dict__['pix_fmt']
+        return f
+
+    @property
+    def frames(self):
+        """
+        Returns the length of a video stream in frames. Returns 0 if not a video stream.
+        """
+        f=None
+        if self.is_video or self.is_audio:
+            if self.__dict__['_nb_frames']:
+                try:
+                    f=int(self.__dict__['_nb_frames'])
+                except ValueError:
+                    raise FFProbeException("None integer frame count")
+        return f
+
+    @property
+    def duration_seconds(self):
+        """
+        Returns the runtime duration of the video stream as a floating point number of seconds.
+        Returns 0.0 if not a video stream.
+        """
+        f=None
+        if self.is_video or self.is_audio:
+            if self.__dict__['_duration']:
+                try:
+                    f=float(self.__dict__['_duration'])
+                except ValueError:
+                    raise FFProbeException("None numeric duration")
+        return f
+
+    @property
+    def language(self):
+        """
+        Returns language tag of stream. e.g. eng
+        """
+        lang=None
+        if self.__dict__['_TAG:language']:
+            lang=self.__dict__['_TAG:language']
+        return lang
+
+    @property
+    def bitrate(self):
+        """
+        Returns bitrate as an integer in bps
+        """
+        b=None
+        if self.__dict__['_bit_rate']:
+            try:
+                b=int(self.__dict__['_bit_rate'])
+            except ValueError:
+                raise FFProbeException("None integer bitrate")
+        return b

--- a/vi3o/imageio.py
+++ b/vi3o/imageio.py
@@ -1,6 +1,7 @@
 from __future__ import division
 import imageio, os
 from vi3o.utils import SlicedView
+from vi3o import ffprobe
 
 class ImageioVideo(object):
     def __init__(self, filename, grey=False):
@@ -15,9 +16,30 @@ class ImageioVideo(object):
         self.fps = self.reader.get_meta_data()['fps']
         if self.fps == 0:
             self.fps = 25
+        self.filename = filename
+        self._nframes = None
 
     def __len__(self):
-        return len(self.reader)
+        if self._nframes is not None:
+            return self._nframes
+        try:
+            nframes = self.reader._meta["nframes"]
+            if nframes == float("inf"):
+                # imageio-ffmpeg has problem with e.g. mp4 videos, test
+                # ffprobe instead
+                try:
+                    nframes = ffprobe.FFProbe(self.filename).video[0].frames
+                    if not nframes:
+                        raise ValueError()
+                except (IOError, IndexError, ValueError, ffprobe.FFProbeException):
+                    # As a last fallback, try to step through all the frames and
+                    # count them. This is very slow since it decodes all frame data..
+                    nframes = self._count_frames()
+        except (AttributeError, KeyError):
+            # For legacy compatibility, not sure if this is needed or not...
+            nframes = len(self.reader)
+        self._nframes = nframes
+        return nframes
 
     def __getitem__(self, item):
         if isinstance(item, slice):
@@ -30,3 +52,8 @@ class ImageioVideo(object):
     @property
     def systimes(self):
         return [i / self.fps for i in range(len(self))]
+
+    def _count_frames(self):
+        print("WARNING: Can't infer length of stream, trying to count...")
+        self._nframes = sum(1 for _ in iter(self))
+        return self._nframes


### PR DESCRIPTION
len() property for .mp4 videos return a large (bogus?) value. The following can be replicated on e.g. [this video](https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mp4-file.mp4).

```
>>> import vi3o;
>>> v = vi3o.Video("test.mp4")
>>> len(v)
9223372036854775807
```
The proposed solution here will detect when the length is not known and tries to count the frames. I am not sure that is what we want to do, another option would be to raise an exception and let the user deal with the problem. A third option is to implement a quicker method to count the frames, e.g. using ffprobe. With this specific video ffprobe takes 84mS while this implementation takes 847mS.

```
$ time ffprobe -v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets -of csv=p=0 ~/Downloads/test.mp4
1889
ffprobe -v error -select_streams v:0 -count_packets -show_entries  -of csv=p=  0.05s user 0.03s system 99% cpu 0.084 total

$ python -c "from timeit import timeit; print(timeit('len(v)', setup='import vi3o; v=vi3o.Video(\"$HOME/Downloads/test.mp4\")'))" 
WARNING: Asked for length of infinite stream, trying to count...
0.8472532397136092

$ time python -c "import vi3o; len(vi3o.Video(\"$HOME/Downloads/test.mp4\"))"
WARNING: Asked for length of infinite stream, trying to count...
python -c "import vi3o; len(vi3o.Video(\"$HOME/Downloads/test.mp4\"))"  1.51s user 0.44s system 299% cpu 0.651 total
```

What do you think @hakanardo?

Asking for the the nframes meta data returns
inf. This commit deals with it by trying to count the frames. This could
take a very long time and the stream could even be an infinitely long
live stream, in that case the len() function will hang forever.

It does however make the API work as one would assume it to work.