### PR TITLE
Draw 1 channel images as gray in debugviewer

### DIFF
--- a/vi3o/debugview.py
+++ b/vi3o/debugview.py
@@ -195,7 +195,7 @@ class DebugViewer(object):
             resize = img.shape != self.prev_image_shape
         self.prev_image_shape = img.shape
 
-        if len(img.shape) == 3:
+        if len(img.shape) == 3 and img.shape[2] == 3:
             f = 'RGB'
             pitch = -img.shape[1] * 3
         else:


### PR DESCRIPTION
An image with shape (h, w, 1) should be rendered as a gray image. For
cases where the number of channels is not 1 or 3 it is more unclear what
would be the best action to perform, this implementation falls back to
gray which I think makes it easier to understand the actual structure of
the frame.